### PR TITLE
Fixed init.rb for Redmine 5.X

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,25 +1,16 @@
-require 'redmine'
-Rails.configuration.to_prepare do
-  require_dependency 'project'
-  require_dependency 'principal'
-  require_dependency 'user'
-  require_dependency 'issue'
-  require_dependency 'issue_query'
-  require_dependency 'mailer'
+require File.expand_path('lib/custom_users_as_assignees', __dir__)
 
-  unless Issue.included_modules.include? CustomUsersAsAssignees::IssuePatch
-    Issue.send :include, CustomUsersAsAssignees::IssuePatch
-  end
-  unless User.included_modules.include? CustomUsersAsAssignees::UserPatch
-    User.send :include, CustomUsersAsAssignees::UserPatch
-  end
-  unless IssueQuery.included_modules.include? CustomUsersAsAssignees::IssueQueryPatch
-    IssueQuery.send :include, CustomUsersAsAssignees::IssueQueryPatch
-  end
-  unless Mailer.included_modules.include? CustomUsersAsAssignees::MailerPatch
-    Mailer.send :include, CustomUsersAsAssignees::MailerPatch
-  end
-
+unless Issue.included_modules.include? CustomUsersAsAssignees::IssuePatch
+  Issue.send :include, CustomUsersAsAssignees::IssuePatch
+end
+unless User.included_modules.include? CustomUsersAsAssignees::UserPatch
+  User.send :include, CustomUsersAsAssignees::UserPatch
+end
+unless IssueQuery.included_modules.include? CustomUsersAsAssignees::IssueQueryPatch
+  IssueQuery.send :include, CustomUsersAsAssignees::IssueQueryPatch
+end
+unless Mailer.included_modules.include? CustomUsersAsAssignees::MailerPatch
+  Mailer.send :include, CustomUsersAsAssignees::MailerPatch
 end
 
 Redmine::Plugin.register :custom_users_as_assignees do
@@ -30,3 +21,4 @@ Redmine::Plugin.register :custom_users_as_assignees do
   url 'https://github.com/preciousplum/custom_users_as_assignees'
   author_url 'https://github.com/preciousplum/'
 end
+


### PR DESCRIPTION
Hello,
I found the two issues why the plugin was not compatible with Redmine 5.X:
1. `require 'redmine'` does not work anymore in recent Redmine/Rails versions (See https://www.redmine.org/boards/2/topics/67113 )
2.  `Rails.configuration.to_prepare do` is also deprecated in Redmine 5.X (See https://www.redmine.org/issues/36245 )

Please review and verify this PR.

Thanks a lot for this awesome plugin :)